### PR TITLE
Updated for Spigot/Bukkit 1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 *.jar
 *.war
 *.ear
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen

--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,15 @@
     </build>
     
     <repositories>
+
+        <!-- Spigot and Bukkit API repository -->
         <repository>
-            <id>bukkit repo</id>
-            <url>http://repo.bukkit.org/content/groups/public</url>
-        </repository>  
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+
         <repository>
+
             <id>myoc-repo</id>
             <url>http://jeterlp.admincmd.com/maven-repo/</url>
         </repository>      
@@ -93,7 +97,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <version>1.9-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -101,7 +105,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <version>1.9-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>MakeYourOwnCommands</artifactId>
     <name>MakeYourOwnCommands</name>
     <inceptionYear>2013</inceptionYear>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.3-SNAPSHOT</version>
     
     <scm>
         <connection>scm:git:git@github.com:TheJeterLP/MakeYourOwnCommands.git</connection>
@@ -80,7 +80,7 @@
     
     <repositories>
 
-        <!-- Spigot and Bukkit API repository -->
+        <!-- Spigot repository -->
         <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
@@ -114,7 +114,7 @@
             <artifactId>Updater</artifactId>
             <version>1.0.0-SNAPSHOT</version>
             <scope>compile</scope>
-        </dependency>    
+        </dependency>
     </dependencies>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,21 @@
         </repository>      
     </repositories>
     <dependencies>
+        <!--Spigot API-->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!--Bukkit API-->
         <dependency>
             <groupId>org.bukkit</groupId>
-            <artifactId>craftbukkit</artifactId>
-            <version>1.7.5-R0.1-SNAPSHOT</version>
-        </dependency>  
+            <artifactId>bukkit</artifactId>
+            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
         
         <dependency>
             <groupId>de.TheJeterLP.Bukkit</groupId>

--- a/src/main/java/de/JeterLP/MakeYourOwnCommands/Command/Command.java
+++ b/src/main/java/de/JeterLP/MakeYourOwnCommands/Command/Command.java
@@ -3,14 +3,14 @@ package de.JeterLP.MakeYourOwnCommands.Command;
 import de.JeterLP.MakeYourOwnCommands.Events.PlayerRunMyocCommandEvent;
 import de.JeterLP.MakeYourOwnCommands.Main;
 import de.JeterLP.MakeYourOwnCommands.utils.LocationHelper;
-import java.util.Collections;
-import java.util.List;
-import javax.annotation.Nonnull;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author TheJeterLP
@@ -85,7 +85,6 @@ public class Command {
     /**
      * @return valid: If the command was successfully initialized.
      */
-    @Nonnull
     public boolean isValid() {
         return valid;
     }

--- a/src/main/java/de/JeterLP/MakeYourOwnCommands/Command/CommandManager.java
+++ b/src/main/java/de/JeterLP/MakeYourOwnCommands/Command/CommandManager.java
@@ -1,14 +1,15 @@
 package de.JeterLP.MakeYourOwnCommands.Command;
 
 import de.JeterLP.MakeYourOwnCommands.Main;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import org.bukkit.Bukkit;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.entity.Player;
 
 /**
  * @author TheJeterLP
@@ -77,7 +78,7 @@ public class CommandManager {
     public static String replaceValues(String message, Player player, String[] args) {
         message = message.replaceAll("%sender%", player.getName())
                 .replaceAll("%realtime%", format.format(new Date()))
-                .replaceAll("%onlineplayers%", String.valueOf(Bukkit.getOnlinePlayers().length))
+                .replaceAll("%onlineplayers%", String.valueOf(Bukkit.getOnlinePlayers().size()))
                 .replaceAll("%world%", player.getWorld().getName())
                 .replace("%cmd%", message);
         String names = "";

--- a/src/main/java/de/JeterLP/MakeYourOwnCommands/utils/Metrics.java
+++ b/src/main/java/de/JeterLP/MakeYourOwnCommands/utils/Metrics.java
@@ -332,7 +332,7 @@ public class Metrics {
         boolean onlineMode = Bukkit.getServer().getOnlineMode(); // TRUE if online mode is enabled
         String pluginVersion = description.getVersion();
         String serverVersion = Bukkit.getVersion();
-        int playersOnline = Bukkit.getServer().getOnlinePlayers().length;
+        int playersOnline = Bukkit.getServer().getOnlinePlayers().size();
 
         // END server software specific section -- all code below does not use any code outside of this class / Java
 


### PR DESCRIPTION
Hey, since 1.9 came out yesterday, `Bukkit#getServer()#getOnlinePlayers()` was removed/changed. It now no longer returns an array, but a collection. Which broke a few things in this plugin. I fixed them. You need to either update your Updater library as well, or accept the pull request I made for it (_And make a new maven release, ofcourse_), the bukkit version you defined in your pom.xml there was no longer available. So I updated that to 1.9 as well.
